### PR TITLE
Add sessionManagerServerWorkerServiceAddr to values.yaml

### DIFF
--- a/agent/cmd/root.go
+++ b/agent/cmd/root.go
@@ -37,7 +37,16 @@ func run(ctx context.Context, c *config.Config) error {
 	errC := make(chan error)
 
 	// HTTP tunnel.
-	urlHTTP, err := url.Parse(c.Proxy.HTTP.URL)
+	baseURL := c.Proxy.BaseURL
+	if baseURL == "" {
+		// Construct the base URL from c.SessionManagerServerWorkerServiceAddr.
+		prefix := "http://"
+		if c.Proxy.TLS.Enable {
+			prefix = "https://"
+		}
+		baseURL = fmt.Sprintf("%s:%s", prefix, c.SessionManagerServerWorkerServiceAddr)
+	}
+	urlHTTP, err := url.Parse(baseURL + c.Proxy.HTTP.Path)
 	if err != nil {
 		return err
 	}
@@ -56,7 +65,7 @@ func run(ctx context.Context, c *config.Config) error {
 	}
 
 	// HTTP upgrade tunnel.
-	urlUpgrade, err := url.Parse(c.Proxy.Upgrade.URL)
+	urlUpgrade, err := url.Parse(baseURL + c.Proxy.Upgrade.Path)
 	if err != nil {
 		return err
 	}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	Proxy Proxy `yaml:"proxy"`
 	Envoy Envoy `yaml:"envoy"`
 
+	SessionManagerServerWorkerServiceAddr string `yaml:"sessionManagerServerWorkerServiceAddr"`
+
 	// HTTPPort is the port that the agent listens on for HTTP connections.
 	HTTPPort int `yaml:"httpPort"`
 }
@@ -33,6 +35,11 @@ func (c *Config) Validate() error {
 	if c.HTTPPort <= 0 {
 		return fmt.Errorf("httpPort must be greater than 0")
 	}
+
+	if c.SessionManagerServerWorkerServiceAddr == "" && c.Proxy.BaseURL == "" {
+		return fmt.Errorf("sessionManagerServerWorkerServiceAddr or proxy.BaseURL must be set")
+	}
+
 	return nil
 
 }
@@ -51,6 +58,7 @@ func (a *Admin) validate() error {
 
 // Proxy is the configuration for connecting to the proxy.
 type Proxy struct {
+	BaseURL string `yaml:"baseUrl"`
 	HTTP    Tunnel `yaml:"http"`
 	Upgrade Tunnel `yaml:"upgrade"`
 
@@ -69,14 +77,14 @@ func (p *Proxy) validate() error {
 
 // Tunnel is the configuration for a tunnel.
 type Tunnel struct {
-	URL         string        `yaml:"url"`
+	Path        string        `yaml:"path"`
 	PoolSize    int           `yaml:"poolSize"`
 	DialTimeout time.Duration `yaml:"dialTimeout"`
 }
 
 func (t *Tunnel) validate() error {
-	if t.URL == "" {
-		return fmt.Errorf("url must be set")
+	if t.Path == "" {
+		return fmt.Errorf("path must be set")
 	}
 	if t.PoolSize <= 0 {
 		return fmt.Errorf("poolSize must be greater than 0")

--- a/deployments/agent/templates/configmap.yaml
+++ b/deployments/agent/templates/configmap.yaml
@@ -10,16 +10,18 @@ data:
     admin:
       socket: /tmp/sockets/admin.sock
     proxy:
+      baseUrl {{ .Values.proxy.baseUrl }}
       http:
-        url: {{ .Values.proxy.baseUrl }}/v1/sessions-worker-service/http
+	path /v1/sessions-worker-service/http
         poolSize: {{ $.Values.proxy.http.poolSize }}
         dialTimeout: 5s
       upgrade:
-        url: {{ .Values.proxy.baseUrl }}/v1/sessions-worker-service/upgrade
+        path: /v1/sessions-worker-service/upgrade
         poolSize: {{ $.Values.proxy.upgrade.poolSize }}
         dialTimeout: 5s
       tls:
         enable: {{ .Values.global.worker.tls.enable }}
+    sessionManagerServerWorkerServiceAddr: {{ .Values.sessionManagerServerWorkerServiceAddr }}
     envoy:
       socket: /tmp/sockets/envoy.sock
     httpPort: {{ .Values.httpPort }}

--- a/deployments/agent/values.yaml
+++ b/deployments/agent/values.yaml
@@ -10,7 +10,8 @@ global:
 envoyClusterId: local-cluster-id
 
 proxy:
-  baseUrl: http://session-manager-server-worker-service-http:8082
+  # Deprecated. Use sessionManagerServerWorkerServiceAddr instead.
+  baseUrl:
   http:
     # pool size of the HTTP tunnel
     # Currently server supports only one channel per agent.
@@ -18,6 +19,9 @@ proxy:
   upgrade:
     # pool size of the HTTP upgrade tunnel
     poolSize: 10
+
+# This default value works if session-manager-server runs in the same namespace.
+sessionManagerServerWorkerServiceAddr: session-manager-server-worker-service-http:8082
 
 httpPort: 8080
 


### PR DESCRIPTION
We used to use proxy.baseUrl to set the address of session-manager-server, but this format is not consistent with other components.

Define sessionManagerServerWorkerServiceAddr as it is more aligned with others. Still keep proxy.baseUrl for backward compatibility.