### PR TITLE
fix: do not use .global.worker.controlPlaneAddr for sessionManagerServerWorkerServiceAddr

### DIFF
--- a/deployments/agent/templates/configmap.yaml
+++ b/deployments/agent/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
         dialTimeout: 5s
       tls:
         enable: {{ .Values.global.worker.tls.enable }}
-    sessionManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.sessionManagerServerWorkerServiceAddr }}
+    sessionManagerServerWorkerServiceAddr: {{ .Values.sessionManagerServerWorkerServiceAddr }}
     envoy:
       socket: /tmp/sockets/envoy.sock
     httpPort: {{ .Values.httpPort }}


### PR DESCRIPTION
sessionManagerServerWorkerServiceAddr is often needed to be a value different than the control plane addr to support HTTP Connect.