### PR TITLE
fix: check enableOkta before checking DexServer

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -20,10 +20,8 @@ data:
         {{- if .Values.global.auth.enable }}
         rbacServer:
           addr: {{ .Values.global.auth.rbacInternalServerAddr }}
-        {{- with .Values.global.auth.dexServerAddr }}
         dexServer:
-          addr: {{ . }}
-        {{- end }}
+          addr: {{ .Values.global.auth.dexServerAddr }}
         oidc:
           issuerUrl: {{ default (printf "%s/v1/dex" .Values.global.ingress.controllerUrl) .Values.auth.oidcIssuerId }}
           clientId: {{ .Values.auth.oidcClientId }}

--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -59,7 +59,34 @@ func run(ctx context.Context, c *config.Config) error {
 	)
 
 	var tex auth.TokenExchanger
-	if c.Server.Auth.DexServer != nil {
+	if c.Server.Auth.EnableOkta {
+		oauth2Config, err := newOauth2Config(ctx, c.Server.Auth.OIDC)
+		if err != nil {
+			return fmt.Errorf("new oauth2 config: %s", err)
+		}
+		// TODO(guangrui): Generate state and code verifier per login session.
+		state := getRandomString(64)
+		codeVerifier := getRandomString(64)
+		tex, err = auth.NewOktaTokenExchanger(oauth2Config, state, codeVerifier)
+		if err != nil {
+			return fmt.Errorf("new okta token exchanger: %w", err)
+		}
+		ea, err := auth.NewExternalAuthenticator(
+			ctx,
+			c.Server.Auth.RBACServer.Addr,
+			tex,
+			c.Server.Auth.CacheExpiration,
+			c.Server.Auth.CacheCleanup,
+			c.Server.Slurm.Enable,
+			state,
+		)
+		if err != nil {
+			return fmt.Errorf("new worker authenticator: %w", err)
+		}
+		eauth = ea
+		loginFn = ea.HandleLogin
+		callbackFn = ea.HandleLoginCallback
+	} else if c.Server.Auth.DexServer != nil {
 		var err error
 		tex, err = auth.NewDexTokenExchanger(ctx, auth.TokenExchangerOptions{
 			ClientID:     c.Server.Auth.OIDC.ClientID,
@@ -80,33 +107,6 @@ func run(ctx context.Context, c *config.Config) error {
 			c.Server.Auth.CacheCleanup,
 			c.Server.Slurm.Enable,
 			"",
-		)
-		if err != nil {
-			return fmt.Errorf("new worker authenticator: %w", err)
-		}
-		eauth = ea
-		loginFn = ea.HandleLogin
-		callbackFn = ea.HandleLoginCallback
-	} else if c.Server.Auth.EnableOkta {
-		oauth2Config, err := newOauth2Config(ctx, c.Server.Auth.OIDC)
-		if err != nil {
-			return fmt.Errorf("new oauth2 config: %s", err)
-		}
-		// TODO(guangrui): Generate state and code verifier per login session.
-		state := getRandomString(64)
-		codeVerifier := getRandomString(64)
-		tex, err = auth.NewOktaTokenExchanger(oauth2Config, state, codeVerifier)
-		if err != nil {
-			return fmt.Errorf("new okta token exchanger: %w", err)
-		}
-		ea, err := auth.NewExternalAuthenticator(
-			ctx,
-			c.Server.Auth.RBACServer.Addr,
-			tex,
-			c.Server.Auth.CacheExpiration,
-			c.Server.Auth.CacheCleanup,
-			c.Server.Slurm.Enable,
-			state,
 		)
 		if err != nil {
 			return fmt.Errorf("new worker authenticator: %w", err)


### PR DESCRIPTION
Setting DexServer to nil requires some additional work since the value comes from the 'global' field. It is easier to use Okta if enableOkta is set to true regardless of the value of DexServer.